### PR TITLE
workflow: Disable token on checkout

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,10 +34,6 @@ jobs:
         sudo apt install -y gcc-11 g++-11
         sudo apt install -y libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev mesa-common-dev libglvnd-dev libpulse-dev
     - uses: actions/checkout@v2
-      with:
-        submodules: true
-        token: ${{ secrets.REPOSITORY_TOKEN }}
-
     - name: Mount bazel cache
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
The repository is now public and should not need a custom token